### PR TITLE
Add "coverage" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Example
 -------
 
 ```bash
-$ xp test -l unittest.coverage.CoverageListener - -o registerpath src/main/php src/test/php
+$ xp coverage -p src/main/php src/test/php
 # ...
 ```
 
-Now open ./code-coverage-report/index.html in your browser
+Now open *./code-coverage-report/index.html* in your browser

--- a/bin/xp.xp-forge.coverage
+++ b/bin/xp.xp-forge.coverage
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+This must be run from within an XP runner

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "phpunit/php-code-coverage": "^6.0 | ^5.3",
     "php": ">=7.0.0"
   },
+  "bin": ["bin/xp.xp-forge.coverage"],
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]
   }

--- a/src/main/php/xp/coverage/Runner.class.php
+++ b/src/main/php/xp/coverage/Runner.class.php
@@ -5,7 +5,7 @@ use lang\{XPClass, Throwable};
 use util\cmd\Console;
 
 /**
- * Runs unittests, measures coverage and displays a summary
+ * Runs unittests, measures coverage and generates a report
  * ========================================================================
  *
  * - Runs tests in src/test/php, measuring coverage of src/main/php

--- a/src/main/php/xp/coverage/Runner.class.php
+++ b/src/main/php/xp/coverage/Runner.class.php
@@ -46,7 +46,7 @@ class Runner {
     }
 
     try {
-      XPClass::forName('xp.unittest.TestRunner')->getMethod('main')->invoke(null, [$pass]);
+      return XPClass::forName('xp.unittest.TestRunner')->getMethod('main')->invoke(null, [$pass]);
     } catch (TargetInvocationException $e) {
       Console::$err->writeLine($e->getCause());
       return 2;

--- a/src/main/php/xp/coverage/Runner.class.php
+++ b/src/main/php/xp/coverage/Runner.class.php
@@ -1,0 +1,58 @@
+<?php namespace xp\coverage;
+
+use lang\reflect\TargetInvocationException;
+use lang\{XPClass, Throwable};
+use util\cmd\Console;
+
+/**
+ * Runs unittests, measures coverage and displays a summary
+ * ========================================================================
+ *
+ * - Runs tests in src/test/php, measuring coverage of src/main/php
+ *   ```sh
+ *   $ xp coverage -p src/main/php src/test/php
+ *   ```
+ * - Same as above, additionally generate a *clover.xml* file
+ *   ```sh
+ *   $ xp coverage -p src/main/php -c clover.xml src/test/php
+ *   ```
+ *
+ * The HTML report is generated to *./code-coverage-report/index.html* by
+ * default. The directory name can be changed by using the `-r` option.
+ */
+class Runner {
+
+  /** @return int */
+  public static function main(array $args) {
+
+    // Generate arguments to `xp test`
+    $pass= ['-l', 'unittest.coverage.CoverageListener', '-'];
+    for ($i= 0, $s= sizeof($args); $i < $s; $i++) {
+      if ('-p' === $args[$i]) {
+        $pass[]= '-o';
+        $pass[]= 'registerpath';
+        $pass[]= $args[++$i];
+      } else if ('-r' === $args[$i]) {
+        $pass[]= '-o';
+        $pass[]= 'htmlreportdirectory';
+        $pass[]= $args[++$i];
+      } else if ('-c' === $args[$i]) {
+        $pass[]= '-o';
+        $pass[]= 'cloverfile';
+        $pass[]= $args[++$i];
+      } else {
+        $pass[]= $args[$i];
+      }
+    }
+
+    try {
+      XPClass::forName('xp.unittest.TestRunner')->getMethod('main')->invoke(null, [$pass]);
+    } catch (TargetInvocationException $e) {
+      Console::$err->writeLine($e->getCause());
+      return 2;
+    } catch (Throwable $e) {
+      Console::$err->writeLine($e);
+      return 1;
+    }
+  }
+}


### PR DESCRIPTION
Solves the need for supplying lengthy command lines such as:

```bash
$ xp test -l unittest.coverage.CoverageListener - -o registerpath src/main/php src/test/php
#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#         This is necessary to instantiate and configure the coverage library!
```

...by implementing an XP subcommand. This also makes it possible to install this dependency globally via `composer global require xp-forge/coverage` instead of having to add it to the dev-dependencies of each and every project.

## Usage

![image](https://user-images.githubusercontent.com/696742/45598017-25506b00-b9d5-11e8-8d5c-bf5bd7202d6c.png)
