### PR TITLE
Add coverage metrics to unittest results

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Coverage for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^9.0 | ^8.0 | ^7.0",
+    "xp-framework/core": "^9.0 | ^8.0",
     "xp-framework/unittest": "^9.7",
     "phpunit/php-code-coverage": "^6.0 | ^5.3",
     "php": ">=7.0.0"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0",
-    "xp-framework/unittest": "^9.0 | ^8.0 |^7.0",
+    "xp-framework/unittest": "^9.7",
     "phpunit/php-code-coverage": "^6.0 | ^5.3",
     "php": ">=7.0.0"
   },

--- a/src/main/php/unittest/coverage/CoverageListener.class.php
+++ b/src/main/php/unittest/coverage/CoverageListener.class.php
@@ -146,5 +146,7 @@ class CoverageListener implements TestListener {
     }
 
     (new Facade())->process($this->coverage, $this->htmlReportDirectory);
+
+    $result->metric('Coverage', new CoveredLines($this->coverage));
   }
 }

--- a/src/main/php/unittest/coverage/CoveredLines.class.php
+++ b/src/main/php/unittest/coverage/CoveredLines.class.php
@@ -2,6 +2,11 @@
 
 use unittest\metrics\Metric;
 
+/**
+ * Covered lines metric
+ *
+ * @test  xp://unittest.coverage.tests.CoveredLinesTest
+ */
 class CoveredLines extends Metric {
   private $coverage, $executed, $executable;
 

--- a/src/main/php/unittest/coverage/CoveredLines.class.php
+++ b/src/main/php/unittest/coverage/CoveredLines.class.php
@@ -1,0 +1,36 @@
+<?php namespace unittest\coverage;
+
+use unittest\metrics\Metric;
+
+class CoveredLines extends Metric {
+  private $coverage, $executed, $executable;
+
+  /** @param SebastianBergmann.CodeCoverage.CodeCoverage $coverage */
+  public function __construct($coverage) {
+    $this->coverage= $coverage;
+  }
+
+  /** @return void */
+  protected function calculate() {
+    $report= $this->coverage->getReport();
+    $this->executed= $report->getNumExecutedLines();
+    $this->executable= $report->getNumExecutableLines();
+  }
+
+  /** @return string */
+  protected function format() {
+    $percent= $this->executed / $this->executable * 100;
+    return sprintf(
+      "%s%.2f%%\033[0m lines covered (%d/%d)",
+      $percent < 50.0 ? "\033[31;1m" : ($percent < 90.0 ? "\033[33;1m" : "\033[32;1m"),
+      $percent,
+      $this->executed,
+      $this->executable
+    );
+  }
+
+  /** @return var */
+  protected function value() {
+    return $this->executed / $this->executable * 100;
+  }
+}

--- a/src/test/php/unittest/coverage/tests/CoverageListenerTest.class.php
+++ b/src/test/php/unittest/coverage/tests/CoverageListenerTest.class.php
@@ -11,11 +11,14 @@ class CoverageListenerTest extends TestCase {
   }
 
   #[@test]
-  public function run() {
+  public function run_creates_metrics() {
     $suite= new TestSuite();
+    $result= new TestResult();
 
     $l= new CoverageListener();
     $l->testRunStarted($suite);
-    $l->testRunFinished($suite, new TestResult());
+    $l->testRunFinished($suite, $result);
+
+    $this->assertTrue(array_key_exists('Coverage', $result->metrics()));
   }
 }

--- a/src/test/php/unittest/coverage/tests/CoveredLinesTest.class.php
+++ b/src/test/php/unittest/coverage/tests/CoveredLinesTest.class.php
@@ -1,0 +1,39 @@
+<?php namespace unittest\coverage\tests;
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use unittest\TestCase;
+use unittest\coverage\CoveredLines;
+
+class CoveredLinesTest extends TestCase {
+
+  #[@test]
+  public function can_create() {
+    new CoveredLines(new CodeCoverage());
+  }
+
+  #[@test, @values([
+  #  [[1 => []], 0.0],
+  #  [[1 => ['test']], 100.0],
+  #  [[1 => [], 2 => ['test']], 50.0],
+  #  [[1 => [], 2 => ['test'], 3 => null], 50.0],
+  #])]
+  public function calculated($lines, $expected) {
+    $coverage= new CodeCoverage();
+    $coverage->setData([__FILE__ => $lines]);
+
+    $this->assertEquals($expected, (float)(new CoveredLines($coverage))->calculated());
+  }
+
+  #[@test, @values([
+  #  [[1 => []], '0.00% lines covered (0/1)'],
+  #  [[1 => ['test']], '100.00% lines covered (1/1)'],
+  #  [[1 => [], 2 => ['test']], '50.00% lines covered (1/2)'],
+  #  [[1 => [], 2 => ['test'], 3 => null], '50.00% lines covered (1/2)'],
+  #])]
+  public function formatted($lines, $expected) {
+    $coverage= new CodeCoverage();
+    $coverage->setData([__FILE__ => $lines]);
+
+    $this->assertEquals($expected, preg_replace('/\033.+m/U', '', (new CoveredLines($coverage))->formatted()));
+  }
+}


### PR DESCRIPTION
Using the [new metrics API](https://github.com/xp-framework/unittest/issues/34), add a line showing the line coverage to the unittest output:

![image](https://user-images.githubusercontent.com/696742/45600085-25f9f900-b9f7-11e8-8c78-a83120556e5d.png)

![image](https://user-images.githubusercontent.com/696742/45600255-044e4100-b9fa-11e8-90f9-b009feb23c10.png)
