### PR TITLE
Use dedicated command line arguments for reports...

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Coverage: 84.72% lines covered (61/72)
 
 An optional HTML report can be generated like this. 
 
-`xp coverage -p src/main/php src/test/php/ -o htmlreportdirectory report`
+```bash
+$ xp coverage -p src/main/php -r ./coverage-report src/test/php/
+```
 
 Use it in order to find out how to improve your coverage.
 
@@ -42,4 +44,6 @@ Use it in order to find out how to improve your coverage.
 
 A [clover](https://www.atlassian.com/software/clover) report can be generated as well.
 
-`xp coverage -p src/main/php src/test/php/ -o cloverfile clo.xml`
+```bash
+$ xp coverage -p src/main/php -c clover.xml src/test/php/
+```


### PR DESCRIPTION
...instead of the generic listener options which are passed to the unittest runner. See `xp help coverage`:

```
$ xp help coverage
@FileSystemCL<./src/main/php>
Runs unittests, measures coverage and generates a report
════════════════════════════════════════════════════════════════════════

> Runs tests in src/test/php, measuring coverage of src/main/php

  $ xp coverage -p src/main/php src/test/php

> Same as above, additionally generate a clover.xml file

  $ xp coverage -p src/main/php -c clover.xml src/test/php

> Same as above, additionally generate a HTML report

  $ xp coverage -p src/main/php -r ./coverage-report src/test/php


The -r and -c options can be combined, of course.
```